### PR TITLE
fix package exports

### DIFF
--- a/.changeset/yellow-icons-cheat.md
+++ b/.changeset/yellow-icons-cheat.md
@@ -1,0 +1,5 @@
+---
+'sveltekit-graphql': patch
+---
+
+Fix package exports for sveltekit-graphql/vite

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
 	"bugs": {
 		"url": "https://github.com/StafflinePeoplePlus/sveltekit-graphql/issues"
 	},
-	"types": "./dist/index.d.ts",
 	"bin": {
 		"sveltekit-graphql": "./dist/cli.js"
 	},
@@ -22,6 +21,17 @@
 		"./vite": {
 			"types": "./dist/vite.d.ts",
 			"import": "./dist/vite.js"
+		}
+	},
+	"types": "./dist/index.d.ts",
+	"typesVersions": {
+		"*": {
+			"index.d.ts": [
+				"dist/index.d.ts"
+			],
+			"vite": [
+				"dist/vite.d.ts"
+			]
 		}
 	},
 	"files": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
 	"bugs": {
 		"url": "https://github.com/StafflinePeoplePlus/sveltekit-graphql/issues"
 	},
-	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"bin": {
 		"sveltekit-graphql": "./dist/cli.js"
@@ -18,11 +17,11 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
+			"import": "./dist/index.js"
 		},
 		"./vite": {
 			"types": "./dist/vite.d.ts",
-			"default": "./dist/vite.js"
+			"import": "./dist/vite.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
Should resolve error:
```
Error: Cannot find module 'sveltekit-graphql/vite' or its corresponding type declarations. 
```