### PR TITLE
Update package name to fall under peopleplus org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "sveltekit-graphql",
+	"name": "@peopleplus/sveltekit-graphql",
 	"version": "0.4.4",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
Currently the automated release action is attempting to release to sveltekit-graphql and not the @peopleplus/sveltekit-graphql library